### PR TITLE
Four way junction example

### DIFF
--- a/sim/buildingBlocks/four_way_junction.xodr
+++ b/sim/buildingBlocks/four_way_junction.xodr
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="2" name="" version="1.00" date="Thu Sep  2 20:31:10 2010" north="0.0" south="0.0" east="0.0" west="0.0" />
+
+    <road name="R1" length="1200.0" id="1" junction="1">
+        <link>
+            <successor elementType="junction" elementId="1001" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0" x="100.0" y="300.0" hdg="0.0" length="200.0">
+                <line />
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0">
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal s="180" id="r1_1" name="first" />
+        </signals>
+    </road>
+
+    <road name="R2" length="1200.0" id="2" junction="1">
+        <link>
+            <predecessor elementType="junction" elementId="1" />
+        </link>
+        <planView>
+            <geometry s="0.0" x="300.0" y="300.0" hdg="0.0" length="200.0">
+                <line />
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0">
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <!-- <signals>
+			<signal s="150" id="r2_1" name="first" />
+            <signal s="300" id="r2_2" name="second" />
+        </signals> -->
+    </road>
+
+    <road name="R3" length="1200.0" id="3" junction="1">
+        <link>
+            <successor elementType="junction" elementId="1001" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0" x="310.0" y="500.0" hdg="1.5708" length="200.0">
+                <line />
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0">
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <signals>
+            <signal s="180" id="r2_1" name="second" />
+        </signals>
+    </road>
+
+    <road name="R4" length="1200.0" id="4" junction="1">
+        <link>
+            <predecessor elementType="junction" elementId="1" />
+        </link>
+        <planView>
+            <geometry s="0.0" x="310.0" y="300.0" hdg="1.5708" length="200.0">
+                <line />
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0">
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+
+    <road name="R1234junction" length="1200.0" id="4" junction="1">
+        <link>
+            <predecessor elementType="junction" elementId="1" />
+        </link>
+        <planView>
+            <geometry s="0.0" x="310.0" y="300.0" hdg="1.5708" length="200.0">
+                <line />
+            </geometry>
+        </planView>
+        <lanes>
+            <laneSection s="0.0">
+                <right>
+                    <lane id="-1" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="0">
+                        <width sOffset="0.0" a="10.0" b="0.0" c="0.0" d="0.0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+
+    <controller id="plan1" >
+        <control signalId="r1_1"/>
+        <control signalId="r2_1"/>
+    </controller>
+
+    <junction id="1" name="j1">
+        <connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+            <laneLink from="-2" to="-2" />
+        </connection>
+        <connection id="1" incomingRoad="3" connectingRoad="4" contactPoint="start">
+            <laneLink from="-1" to="-1" />
+            <laneLink from="-2" to="-2" />
+        </connection>    
+    </junction>
+
+</OpenDRIVE>
+

--- a/sim/buildingBlocks/four_way_junction.xprj
+++ b/sim/buildingBlocks/four_way_junction.xprj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Movsim>
+    <VehiclePrototypes>
+        <VehiclePrototypeConfiguration label="IDM1" length="6" maximum_deceleration="9">
+            <AccelerationModelType>
+                <ModelParameterIDM v0="20" T="1.2" s0="3" s1="2" delta="4" a="1.2" b="2.0" />
+            </AccelerationModelType>
+            <LaneChangeModelType european_rules="true" crit_speed_eur="20">
+                <ModelParameterMOBIL safe_deceleration="5.0" minimum_gap="2.0" threshold_acceleration="0.1" right_bias_acceleration="0.05" politeness="0.1" />
+            </LaneChangeModelType>
+        </VehiclePrototypeConfiguration>
+        <VehiclePrototypeConfiguration label="ACC1" length="6" maximum_deceleration="9">
+            <AccelerationModelType>
+                <ModelParameterACC v0="20" T="1.2" s0="3" s1="2" delta="4" a="1.2" b="2.0" coolness="1.0" />
+            </AccelerationModelType>
+            <LaneChangeModelType european_rules="true" crit_speed_eur="20">
+                <ModelParameterMOBIL safe_deceleration="5.0" minimum_gap="2.0" threshold_acceleration="0.1" right_bias_acceleration="0.05" politeness="0.1" />
+            </LaneChangeModelType>
+        </VehiclePrototypeConfiguration>
+        <!-- trucks -->
+        <VehiclePrototypeConfiguration label="IDM2" length="16" maximum_deceleration="9">
+            <AccelerationModelType>
+                <ModelParameterIDM v0="18" T="1.5" s0="4" s1="4" delta="4" a="0.8" b="2.0" />
+            </AccelerationModelType>
+            <LaneChangeModelType european_rules="true" crit_speed_eur="20">
+                <ModelParameterMOBIL safe_deceleration="4.0" minimum_gap="2.0" threshold_acceleration="0.2" right_bias_acceleration="0.3" politeness="0.1" />
+            </LaneChangeModelType>
+        </VehiclePrototypeConfiguration>
+    </VehiclePrototypes>
+    <Scenario network_filename="four_way_junction.xodr">
+        <Simulation timestep="0.2" crash_exit="false">
+            <TrafficComposition>
+                <VehicleType label="IDM1" fraction="0.4" relative_v0_randomization="0.2" />
+                <VehicleType label="ACC1" fraction="0.4" relative_v0_randomization="0.2" />
+                <VehicleType label="IDM2" fraction="0.2" relative_v0_randomization="0.2" />
+            </TrafficComposition>
+            <Road id="1">
+                <InitialConditions />
+                <TrafficSource logging="false">
+                    <Inflow t="0" q_per_hour="500" />
+                </TrafficSource>
+                <Detectors />
+            </Road>
+            <Road id="3">
+                <InitialConditions />
+                <TrafficSource logging="false">
+                    <Inflow t="0" q_per_hour="500" />
+                </TrafficSource>
+                <Detectors />
+            </Road>
+        </Simulation>
+        <TrafficLights logging="true" n_timestep="5">
+            <ControllerGroup id="plan1"  >
+                <Phase duration="30">
+                    <TrafficLightState name="first" status="Red" condition="request"/>
+                    <TrafficLightState name="second" status="Green" condition="clear"/>
+                </Phase>
+                <Phase duration="8">
+                    <TrafficLightState name="first" status="Red" />
+                    <TrafficLightState name="second" status="GreenRed" />
+                </Phase>
+                <Phase duration="8">
+                    <TrafficLightState name="first" status="Red" />
+                    <TrafficLightState name="second" status="Red" />
+                </Phase>
+                <Phase duration="30">
+                    <TrafficLightState name="first" status="Green" condition="clear"/>
+                    <TrafficLightState name="second" status="Red" />
+                </Phase>
+                <Phase duration="8">
+                    <TrafficLightState name="first" status="GreenRed" />
+                    <TrafficLightState name="second" status="Red" />
+                </Phase>
+                <Phase duration="8">
+                    <TrafficLightState name="first" status="Red" />
+                    <TrafficLightState name="second" status="Red" />
+                </Phase>
+            </ControllerGroup>
+        </TrafficLights>
+    </Scenario>
+</Movsim>
+


### PR DESCRIPTION
Added a new "building block" example featuring a simple controlled intersection between two roads. 

At the moment the roads overlap within the MovsimViewer. The example has four straight RoadSegments as this may be a potential method of removing overlap with a junction segment inbetween.
