### PR TITLE
Maven clean up:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ out/
 logs/
 classes/
 
+# maven
+dependency-reduced-pom.xml
+
 # Log file
 *.log
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,28 +26,6 @@
             <version>2.3</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <!-- build executable jar with all dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <!--<version></version>-->
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+
 </project>
 

--- a/consumption/pom.xml
+++ b/consumption/pom.xml
@@ -25,33 +25,39 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
     <build>
-        <plugins>
-            <!-- build executable jar with all dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <!--  <version> </version> -->
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.movsim.consumption.ConsumptionMain</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.3</version>
+				<configuration>
+				<shadedArtifactAttached>true</shadedArtifactAttached>
+				<shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+					<transformers>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+						</transformer>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<Main-Class>org.movsim.MovsimCoreMain</Main-Class>
+							</manifestEntries>
+						</transformer>
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,33 +32,39 @@
             <version>0.8.3</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <!-- build executable jar with all dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <!--  <version> </version> -->
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.movsim.MovsimCoreMain</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    
+    	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.3</version>
+				<configuration>
+				<shadedArtifactAttached>true</shadedArtifactAttached>
+				<shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+					<transformers>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+						</transformer>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<Main-Class>org.movsim.MovsimCoreMain</Main-Class>
+							</manifestEntries>
+						</transformer>
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+    
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <projectVersion>${project.version}</projectVersion>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
         <!-- dependency version -->
         <jdom.version>2.0.2</jdom.version>
@@ -106,16 +105,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!-- execution: mvn javadoc:javadoc -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <configuration>
-                    <show>private</show>
-                    <nohelp>true</nohelp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <!-- mvn findbugs:findbugs -->
                 <!-- mvn findbugs:gui -->
                 <groupId>org.codehaus.mojo</groupId>
@@ -145,12 +134,6 @@
             <artifactId>log4j-core</artifactId>
             <version>2.11.0</version>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>log4j</groupId>-->
-        <!--<artifactId>log4j</artifactId>-->
-        <!--<version>1.2.16</version>-->
-        <!--<type>jar</type>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -210,15 +193,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <reporting>
-        <!-- mvn site -->
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>
 

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -1,52 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    
-    <parent>
-        <groupId>org.movsim</groupId>
-        <artifactId>Movsim</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>MovsimViewer</artifactId>
-    <packaging>jar</packaging>
-    <name>MovsimViewer</name>
-    <description>Graphical user interface and visualization frontend to movsim core.</description>
-    
-    <dependencies>
-        <dependency>
-            <groupId>org.movsim</groupId>
-            <artifactId>MovsimCore</artifactId>
-            <version>${project.version}</version> 
-        </dependency>
-    </dependencies>
-    <build>
-        <plugins>
-            <!-- build executable jar with all dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <!-- <version> </version> -->
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.movsim.viewer.App</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+	<parent>
+		<groupId>org.movsim</groupId>
+		<artifactId>Movsim</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>MovsimViewer</artifactId>
+	<packaging>jar</packaging>
+	<name>MovsimViewer</name>
+	<description>Graphical user interface and visualization frontend to movsim core.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.movsim</groupId>
+			<artifactId>MovsimCore</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.3</version>
+				<configuration>
+				<shadedArtifactAttached>true</shadedArtifactAttached>
+				<shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+					<transformers>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+						</transformer>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<Main-Class>org.movsim.viewer.App</Main-Class>
+							</manifestEntries>
+						</transformer>
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -131,30 +131,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- build executable jar with all dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <!--  <version> </version> -->
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <!--      <manifest>
-                            <mainClass>org.movsim.MovsimCoreMain</mainClass>
-                        </manifest> -->
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Removes javadoc, mvn:site (not needed nor useful)
Moves from assembly plugin to maven shade plugin for core and viewer
 -> (Improves mvn:install by 50% per module and reduces output)